### PR TITLE
Add delete playlist endpoint

### DIFF
--- a/app/src/api/routes/user.ts
+++ b/app/src/api/routes/user.ts
@@ -1,6 +1,10 @@
 import { Router, Request, Response } from "express";
 import { DynamoDBClient, QueryCommand } from "@aws-sdk/client-dynamodb";
-import { PutCommand, DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
+import {
+  PutCommand,
+  DeleteCommand,
+  DynamoDBDocumentClient,
+} from "@aws-sdk/lib-dynamodb";
 
 const router = Router();
 const client = new DynamoDBClient();
@@ -65,5 +69,33 @@ router.get("/:userId", async (req: Request, res: Response) => {
     res.status(500).json({ error: "Failed to fetch user playlists" });
   }
 });
+
+router.delete(
+  "/:userId/:playlistId",
+  async (req: Request, res: Response) => {
+    const { userId, playlistId } = req.params;
+
+    if (!userId) {
+      res.status(400).json({ error: "User ID is required" });
+      return;
+    }
+    if (!playlistId) {
+      res.status(400).json({ error: "Playlist ID is required" });
+      return;
+    }
+
+    try {
+      const command = new DeleteCommand({
+        TableName: "sotf_users",
+        Key: { userId, playlistId },
+      });
+      await docClient.send(command);
+      res.status(200).json({ userId, playlistId });
+    } catch (error) {
+      console.error("Error deleting user playlist:", error);
+      res.status(500).json({ error: "Failed to delete user playlist" });
+    }
+  }
+);
 
 export default router;

--- a/app/src/tests/routes/user.test.ts
+++ b/app/src/tests/routes/user.test.ts
@@ -95,4 +95,21 @@ describe("userRouter", () => {
       ExpressionAttributeValues: { ":uid": "user123" },
     });
   });
+
+  it("DELETE /:userId/:playlistId should delete the playlist for the user", async () => {
+    const docClientSendMock = (
+      DynamoDBDocumentClient.from as jest.Mock
+    ).mock.results[0].value.send;
+
+    const res = await request(app).delete("/user123/playlistXYZ");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ userId: "user123", playlistId: "playlistXYZ" });
+
+    expect(docClientSendMock).toHaveBeenCalledTimes(1);
+    expect(docClientSendMock.mock.calls[0][0].input).toMatchObject({
+      TableName: "sotf_users",
+      Key: { userId: "user123", playlistId: "playlistXYZ" },
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- add `DeleteCommand` logic for removing a playlist
- test removing a playlist mapping

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a5f9231d4832cbe12ec758cae88ba